### PR TITLE
Allow symlinks for local dev site roots

### DIFF
--- a/vagrant/provisioning/files/basebox/usr/local/bin/vhosts.sh
+++ b/vagrant/provisioning/files/basebox/usr/local/bin/vhosts.sh
@@ -222,7 +222,7 @@ function main {
     [[ $reset_config ]] && touch /etc/php-fpm.d/sites.d/empty.conf
     [[ $reset_certs ]] && remove_files $certs_dir/*.c??.pem
 
-    sites_list=$(find $sites_dir -mindepth 1 -maxdepth 1 -type d)
+    sites_list=$(find $sites_dir -mindepth 1 -maxdepth 1 \( -type l -o -type d \))
 
     msg "==> Generating site configuration"
     for site_path in $sites_list; do


### PR DESCRIPTION
When detecting local dev sites (/sites/*.dev), allow symlinks in addition to actual directories. For codebases with an unusual root (such as those inherited from a client's repo), this allows symlinking the web root directory into the expected location so that the dev env works as expected.