### PR TITLE
Add Catalina support

### DIFF
--- a/vagrant/bin/install.sh
+++ b/vagrant/bin/install.sh
@@ -111,7 +111,7 @@ function assert_devenv {
         git fetch -q origin
         git checkout -q master
         vagrant status | grep -v '/etc/profile' || true  # note: expected to spit out error about re-running vagrant
-        echo "==> Please run `source /etc/profile` (bash) or `source /etc/zprofile` in your shell before starting vagrant"
+        echo "==> Please run `source /etc/profile` (bash) or `source ~/.zshrc` (zsh) in your shell before starting vagrant"
 
         made_changes=1
     elif [[ ! -f /Volumes/Server/vagrant/vagrant.rb ]]; then

--- a/vagrant/lib/config.rb
+++ b/vagrant/lib/config.rb
@@ -90,9 +90,12 @@ done
 unset i
 -
 
-    # append script to /etc/profile and then execute that new portion to pickup env configuration
+    # append script to /etc/[z]profile and then execute that new portion to pickup env configuration
     system %-
       printf "\n## VAGRANT START ##%s## VAGRANT END ##\n" '#{profile_script}'| sudo tee \-a /etc/profile > /dev/null
+    -
+    system %-
+      printf "\n## VAGRANT START ##%s## VAGRANT END ##\n" '#{profile_script}'| sudo tee \-a /etc/zprofile > /dev/null
     -
     changes = true
     newsh = true
@@ -128,7 +131,7 @@ unset i
 
   # prevent run if shell doesn't have expected env vars set from profile.d scripts or if changes require such
   if newsh or (changes == false && ENV['VAGRANT_IS_SETUP'] != 'true')
-    puts 'Please re-run the command in a new shell... or type `source /etc/profile` and then try again'
+    puts 'Please re-run the command in a new shell... or type `source /etc/profile` (bash) or `source /etc/zprofile` (zsh) and then try again'
     exit 1
   end
 end

--- a/vagrant/lib/config.rb
+++ b/vagrant/lib/config.rb
@@ -13,7 +13,7 @@
 def base_dir (base_dir)
   # evaluates to true if is not either a valid directory a symlink pointing to a directory
   if !File.directory?(base_dir)
-    throw 'Error: please create a /server link pointing to the environment root'
+    throw 'Error: please create a /Volumes/Server link pointing to the environment root'
   end
 
   # assert base_dir points to our environment root
@@ -120,7 +120,7 @@ unset i
   # verify virtualbox machine directory
   vbox_machine_dir = %x{VBoxManage list systemproperties | grep 'Default machine folder:' | sed 's/.*: *//g'}.strip!
   if vbox_machine_dir != "#{BASE_DIR}/.machines"
-    puts "==> host: Setting global VirtualBox machine folder to /server/.machines"
+    puts "==> host: Setting global VirtualBox machine folder to /Volumes/Server/.machines"
     system %-VBoxManage setproperty machinefolder #{BASE_DIR}/.machines-
     changes = true
   end

--- a/vagrant/lib/config.rb
+++ b/vagrant/lib/config.rb
@@ -90,12 +90,12 @@ done
 unset i
 -
 
-    # append script to /etc/[z]profile and then execute that new portion to pickup env configuration
+    # append script to /etc/profile and ~/.zshrc and then execute that new portion to pickup env configuration
     system %-
       printf "\n## VAGRANT START ##%s## VAGRANT END ##\n" '#{profile_script}'| sudo tee \-a /etc/profile > /dev/null
     -
     system %-
-      printf "\n## VAGRANT START ##%s## VAGRANT END ##\n" '#{profile_script}'| sudo tee \-a /etc/zprofile > /dev/null
+      printf "\n## VAGRANT START ##%s## VAGRANT END ##\n" '#{profile_script}'| sudo tee \-a ~/.zshrc > /dev/null
     -
     changes = true
     newsh = true
@@ -131,7 +131,7 @@ unset i
 
   # prevent run if shell doesn't have expected env vars set from profile.d scripts or if changes require such
   if newsh or (changes == false && ENV['VAGRANT_IS_SETUP'] != 'true')
-    puts 'Please re-run the command in a new shell... or type `source /etc/profile` (bash) or `source /etc/zprofile` (zsh) and then try again'
+    puts 'Please re-run the command in a new shell... or type `source /etc/profile` (bash) or `source ~/.zshrc` (zsh) and then try again'
     exit 1
   end
 end

--- a/vagrant/lib/config.rb
+++ b/vagrant/lib/config.rb
@@ -107,8 +107,7 @@ unset i
     
     mapall = %x{printf $(id \-u):$(grep ^admin: /etc/group | cut \-d : \-f 3)}
     nfs_exports = %-
-#{MOUNT_PATH}/sites/ \-alldirs \-network 10.19.89.0 \-mask 255.255.255.0 \-mapall=#{mapall}
-#{MOUNT_PATH}/mysql/ \-alldirs \-network 10.19.89.0 \-mask 255.255.255.0 \-mapall=#{mapall}
+#{MOUNT_PATH}/ \-alldirs \-network 10.19.89.0 \-mask 255.255.255.0 \-mapall=#{mapall}
 -
     system %-
       printf "\n## VAGRANT START ##%s## VAGRANT END ##\n" '#{nfs_exports}' | sudo tee \-a /etc/exports > /dev/null

--- a/vagrant/lib/mount.rb
+++ b/vagrant/lib/mount.rb
@@ -45,14 +45,6 @@ class Mount
       exit false
     end
 
-    exports = File.readlines('/etc/exports')
-    for line in exports
-      if line.start_with?(host_path + '/ -alldirs')
-        return true
-      end
-    end
-    $stderr.puts "Error: /etc/exports is missing an entry for #{host_path}/. See /Volumes/Server/README.md for details"
-    exit false
   end
 
   # Sets up the vagrant configuration neccesary for the mounts configured via the Mount class

--- a/vagrant/lib/mount.rb
+++ b/vagrant/lib/mount.rb
@@ -41,7 +41,7 @@ class Mount
   # +host_path+:: +String+ path to required share directory
   def self.assert_export (host_path)
     if File.exist?('/etc/exports') == false
-      $stderr.puts "Error: /etc/exports does not exist. See /server/README.md for details"
+      $stderr.puts "Error: /etc/exports does not exist. See /Volumes/Server/README.md for details"
       exit false
     end
 
@@ -51,7 +51,7 @@ class Mount
         return true
       end
     end
-    $stderr.puts "Error: /etc/exports is missing an entry for #{host_path}/. See /server/README.md for details"
+    $stderr.puts "Error: /etc/exports is missing an entry for #{host_path}/. See /Volumes/Server/README.md for details"
     exit false
   end
 

--- a/vagrant/provisioning/files/basebox/etc/profile.d/env.sh
+++ b/vagrant/provisioning/files/basebox/etc/profile.d/env.sh
@@ -17,11 +17,11 @@ export MAGE_MODE=developer
 
 # set vagrant environemnt vars
 export VAGRANT_IS_SETUP=true
-export VAGRANT_HOME=/server/.vagrant
+export VAGRANT_HOME=/Volumes/Server/.vagrant
 export VAGRANT_LOG=
 
 # set central composer home
-export COMPOSER_HOME=/server/.shared/composer
+export COMPOSER_HOME=/Volumes/Server/.shared/composer
 
 # configure PATH to use local and user scripts
 export PATH=~/bin:/usr/local/bin:/server/vagrant/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin

--- a/vagrant/provisioning/files/basebox/etc/profile.d/env.sh
+++ b/vagrant/provisioning/files/basebox/etc/profile.d/env.sh
@@ -24,7 +24,7 @@ export VAGRANT_LOG=
 export COMPOSER_HOME=/Volumes/Server/.shared/composer
 
 # configure PATH to use local and user scripts
-export PATH=~/bin:/usr/local/bin:/server/vagrant/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
+export PATH=~/bin:/usr/local/bin:/Volumes/Server/vagrant/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin
 
 # enbale color-ls emulation
 export CLICOLOR=1

--- a/vagrant/provisioning/files/basebox/etc/profile.d/ps1.sh
+++ b/vagrant/provisioning/files/basebox/etc/profile.d/ps1.sh
@@ -27,7 +27,7 @@ function __git_ps1_devenv {
         return
     fi
     
-    server_path="$(readlink /server || echo /server)"
+    server_path="$(readlink /Volumes/Server || echo /Volumes/Server)"
     if [[ "$(git rev-parse --show-toplevel 2>/dev/null | grep -vE "^$server_path$")" ]]; then
         gs=$(__git_ps1) && [ "$gs" ] && echo "$gs "
     fi

--- a/vagrant/provisioning/files/basebox/usr/local/bin/m2setup.sh
+++ b/vagrant/provisioning/files/basebox/usr/local/bin/m2setup.sh
@@ -15,7 +15,7 @@ wd="$(pwd)"
 trap '>&2 echo Error: Command \`$BASH_COMMAND\` on line $LINENO failed with exit code $?' ERR
 
 # init non-user configurable inputs allowing external override via exports
-test -z $SHARED_DIR && SHARED_DIR=/server/.shared
+test -z $SHARED_DIR && SHARED_DIR=/Volumes/Server/.shared
 test -z $SITES_DIR && SITES_DIR=/var/www/sites
 test -z $INSTALL_DIR && INSTALL_DIR=        # default init'd post argument parsing
 test -z $DB_HOST && DB_HOST=dev-db

--- a/vagrant/provisioning/files/web/etc/openssl/rootca.conf
+++ b/vagrant/provisioning/files/web/etc/openssl/rootca.conf
@@ -6,7 +6,7 @@ default_ca = CA_default
 
 [ CA_default ]
 # Directory and file locations.
-dir               = /server/.shared/ssl/rootca
+dir               = /Volumes/Server/.shared/ssl/rootca
 certs             = $dir/certs
 crl_dir           = $dir/crl
 new_certs_dir     = $dir/newcerts

--- a/vagrant/provisioning/web.yml
+++ b/vagrant/provisioning/web.yml
@@ -90,7 +90,7 @@
           dest: ~/.vimrc
 
       - file:
-          src: /server/.shared/vim/plugin
+          src: /Volumes/Server/.shared/vim/plugin
           dest: ~/.vim/plugin
           state: link
           force: yes

--- a/vagrant/vagrant.rb
+++ b/vagrant/vagrant.rb
@@ -13,7 +13,7 @@ require_relative 'lib/provision'
 require_relative 'lib/machine'
 
 # configure environment paths
-BASE_DIR = base_dir('/server')
+BASE_DIR = base_dir('/Volumes/Server')
 MOUNT_PATH = mount_path(BASE_DIR)
 VAGRANT_DIR = BASE_DIR + '/vagrant'
 SHARED_DIR = BASE_DIR + '/.shared'


### PR DESCRIPTION
Due to Catalina's read only system volume (see https://arstechnica.com/gadgets/2019/10/macos-10-15-catalina-the-ars-technica-review/11/#h1), the /server and /sites convenience symlinks on the host are no longer possible.

This host path was hard coded in a few places, and this commit replaces the path with /Volumes/Server. A better solution would be to not depend on host configuration as much, but this allows the dev env to boot successfully on Catalina (and probably earlier).

The dev env requires certain environmental variables, and assumes the host is using bash. With Catalina's switch to zsh, these no longer take effect.