### PR TITLE
Update composer download URL to always use latest version

### DIFF
--- a/vagrant/provisioning/roles/alpacaglue.composer/defaults/main.yml
+++ b/vagrant/provisioning/roles/alpacaglue.composer/defaults/main.yml
@@ -1,3 +1,3 @@
 composer:
   install_name: composer
-  download_url: https://getcomposer.org/download/1.6.3/composer.phar
+  download_url: https://getcomposer.org/composer-stable.phar


### PR DESCRIPTION
For reasons that aren't clear, the existing composer download URL was fixed at 1.6.3. This commit updates the URL to target the latest stable release.