### PR TITLE
fixed 404 on percona download when bringing up a vagrant box

### DIFF
--- a/vagrant/provisioning/roles/alpacaglue.repo-percona/tasks/main.yml
+++ b/vagrant/provisioning/roles/alpacaglue.repo-percona/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Install Percona Server repo
   yum:
-    name: "https://www.percona.com/downloads/percona-release/redhat/0.1-6/percona-release-0.1-6.noarch.rpm"
+    name: "https://www.percona.com/downloads/percona-release/percona-release-0.1-6/redhat/percona-release-0.1-6.noarch.rpm"
     state: present
   when: not percona_repofile_result.stat.exists
 


### PR DESCRIPTION
Fixed: Fatal: [web72]: FAILED! => {"changed": false, "msg": "Failure downloading https://www.percona.com/downloads/percona-release/redhat/0.1-6/percona-release-0.1-6.noarch.rpm, HTTP Error 404: Not Found"} When running 'vagrant up'